### PR TITLE
Remove superfluous ovrride directive in make check

### DIFF
--- a/Make.mk
+++ b/Make.mk
@@ -251,8 +251,8 @@ dist: dist-source dist-client dist-info
 
 .PHONY: check check-accept _check
 check check-accept: _check
-check:        export override EMPIRE_CHECK_ACCEPT :=
-check-accept: export override EMPIRE_CHECK_ACCEPT := y
+check:        export EMPIRE_CHECK_ACCEPT :=
+check-accept: export EMPIRE_CHECK_ACCEPT := y
 _check: all
 	@echo "Warning: test suite is immature and needs work." >&2
 	$(srcdir)/tests/files-test $(srcdir)


### PR DESCRIPTION
Travis CI and OS X system make on 10.9.x at least don't have GNU make
>=3.82 which contains a parser enhancement that allows multiple
directives.
